### PR TITLE
Normalize OCI Helm Chart sources for Argo CD

### DIFF
--- a/backend/src/mindweaver/platform_service/base.py
+++ b/backend/src/mindweaver/platform_service/base.py
@@ -32,6 +32,19 @@ import yaml
 logger = logging.getLogger(__name__)
 
 
+def normalize_argocd_chart_source(repo: str, chart: str) -> tuple[str, str]:
+    """Return an Argo CD-compatible Helm chart repository and chart name."""
+    if not repo.startswith("oci://"):
+        return repo, chart
+
+    normalized_repo = repo.removeprefix("oci://").rstrip("/")
+    chart_suffix = f"/{chart.strip('/')}" if chart else ""
+    if chart_suffix and normalized_repo.endswith(chart_suffix):
+        normalized_repo = normalized_repo[: -len(chart_suffix)]
+
+    return normalized_repo, chart
+
+
 class PlatformStateBase(Base):
     """Base class for platform deployment status tracking"""
 
@@ -714,7 +727,10 @@ class PlatformService(ProjectScopedService[T], abc.ABC):
         """
         project = await self.project(model)
         if hasattr(self.session, "_mock_name") or "mock" in type(self.session).__name__.lower():
-            return default_repo, default_chart, default_version
+            return (
+                *normalize_argocd_chart_source(default_repo, default_chart),
+                default_version,
+            )
 
         if project.stack_id:
             from mindweaver.service.stack.model import Stack
@@ -725,9 +741,17 @@ class PlatformService(ProjectScopedService[T], abc.ABC):
             if stack:
                 repo, chart, version = stack.get_chart_for_component(component_name, chart_key)
                 if repo or chart or version:
-                    return repo or default_repo, chart or default_chart, version or default_version
+                    return (
+                        *normalize_argocd_chart_source(
+                            repo or default_repo, chart or default_chart
+                        ),
+                        version or default_version,
+                    )
 
-        return default_repo, default_chart, default_version
+        return (
+            *normalize_argocd_chart_source(default_repo, default_chart),
+            default_version,
+        )
 
     async def resolve_chart_version(
         self,

--- a/backend/tests/platform_service/hive_metastore/test_hms.py
+++ b/backend/tests/platform_service/hive_metastore/test_hms.py
@@ -139,6 +139,8 @@ async def test_hms_template_rendering(mock_service_dependencies):
     assert vars["s3_endpoint_url"] == "http://minio:9000"
     assert vars["aws_access_key_id"] == "access"
     assert vars["aws_secret_access_key"] == "secret"
+    assert vars["chart_repo"] == "ghcr.io/kagesenshi/mindweaver/charts"
+    assert vars["chart_name"] == "hive-metastore"
 
     # Check template rendering logic (basic markers)
     import os


### PR DESCRIPTION
## Summary

Normalize OCI Helm chart repository values before generating Argo CD Applications.

## Before

Mindweaver generated an OCI Helm source like this:

```yaml
repoURL: oci://ghcr.io/kagesenshi/mindweaver/charts/hive-metastore
chart: hive-metastore
```

The repository incorrectly contained:

- The `oci://` prefix
- The chart name already specified by the separate `chart` field

This caused Argo CD to fail while generating the application manifests.

## After

Mindweaver now generates:

```yaml
repoURL: ghcr.io/kagesenshi/mindweaver/charts
chart: hive-metastore
```

The repository points to the parent OCI chart repository, while the chart name remains in the separate `chart` field.

## Changes

- Remove the `oci://` prefix from OCI repository values
- Remove a duplicated trailing chart name from the repository
- Leave non-OCI repository values unchanged
- Normalize default and stack-overridden chart sources
- Add regression assertions for Hive Metastore chart rendering

## Testing

- Built the Docker test image
- Ran `tests/platform_service/hive_metastore/test_hms.py`
- Result: 5 tests passed