### PR TITLE
Fix default Kafka deployment configuration

### DIFF
--- a/backend/src/mindweaver/platform_service/kafka/service.py
+++ b/backend/src/mindweaver/platform_service/kafka/service.py
@@ -85,10 +85,18 @@ class KafkaPlatformService(PlatformService[KafkaPlatform]):
         """Resolves template variables required for rendering manifests."""
         vars = model.model_dump()
         vars["image"], vars["image_tag"] = await self.resolve_image(
-            model, "kafka", "apache/kafka", "4.0.0-rev.0"
+            model,
+            "kafka",
+            "quay.io/strimzi/kafka",
+            "0.41.0-kafka-3.7.0",
         )
         chart_repo, chart_name, chart_version = await self.resolve_chart(
-            model, "kafka", "main", "https://github.com/kagesenshi/mindweaver.git", "charts/kafka", "0.1.0"
+            model,
+            "kafka",
+            "main",
+            "https://github.com/kagesenshi/mindweaver.git",
+            "charts/kafka",
+            "main",
         )
         vars["chart_repo"] = chart_repo
         vars["chart_name"] = chart_name

--- a/backend/src/mindweaver/resources/stacks/mindweaver-0.1.0-alpha.1.yml
+++ b/backend/src/mindweaver/resources/stacks/mindweaver-0.1.0-alpha.1.yml
@@ -39,11 +39,11 @@ configuration:
         main:
           repo: https://github.com/kagesenshi/mindweaver.git
           chart: charts/kafka
-          version: "0.1.0"
+          version: main
       images:
         main:
-          image: apache/kafka
-          tag: "4.0.0-rev.0"
+          image: quay.io/strimzi/kafka
+          tag: "0.41.0-kafka-3.7.0"
 
     superset:
       charts:

--- a/backend/tests/platform_service/test_kafka.py
+++ b/backend/tests/platform_service/test_kafka.py
@@ -1,12 +1,35 @@
 # SPDX-FileCopyrightText: Copyright © 2026 Mohd Izhar Firdaus Bin Ismail
 # SPDX-License-Identifier: AGPLv3+
 
+from pathlib import Path
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
 from fastapi import Request
 from pydantic import ValidationError
 from mindweaver.platform_service.kafka import KafkaPlatform, KafkaPlatformService
 from mindweaver.fw.model import AsyncSession
+
+
+def test_kafka_chart_grants_node_reader_for_nodeport_listener():
+    test_file = Path(__file__).resolve()
+    candidate_paths = [
+        root / "charts" / "kafka" / "templates" / "node-reader-rbac.yaml"
+        for root in (test_file.parents[2], test_file.parents[3])
+    ]
+    template_path = next(
+        (path for path in candidate_paths if path.exists()),
+        None,
+    )
+
+    assert template_path is not None, (
+        "Kafka node-reader RBAC template was not found"
+    )
+    template = template_path.read_text(encoding="utf-8")
+
+    assert 'resources: ["nodes"]' in template
+    assert 'verbs: ["get"]' in template
+    assert "name: {{ .Values.fullnameOverride }}-kafka" in template
+    assert "namespace: {{ .Release.Namespace }}" in template
 
 
 @pytest.fixture
@@ -109,6 +132,9 @@ async def test_kafka_template_vars(mock_service_dependencies):
     assert vars["namespace"] == "test-ns"
     assert vars["replica_count"] == 3
     assert vars["storage_size"] == "20Gi"
+    assert vars["image"] == "quay.io/strimzi/kafka"
+    assert vars["image_tag"] == "0.41.0-kafka-3.7.0"
+    assert vars["chart_version"] == "main"
 
 
 @pytest.mark.asyncio
@@ -133,6 +159,9 @@ async def test_kafka_render_manifests(mock_service_dependencies):
     assert "replicaCount: 3" in manifests
     assert "charts/kafka" in manifests
     assert "github.com/kagesenshi/mindweaver" in manifests
+    assert "targetRevision: main" in manifests
+    assert 'repository: "quay.io/strimzi/kafka"' in manifests
+    assert 'tag: "0.41.0-kafka-3.7.0"' in manifests
     assert "size: \"20Gi\"" in manifests
     assert "namespace: test-ns" in manifests
 

--- a/charts/kafka/templates/node-reader-rbac.yaml
+++ b/charts/kafka/templates/node-reader-rbac.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright © 2026 Mohd Izhar Firdaus Bin Ismail
+# SPDX-License-Identifier: AGPLv3+
+
+# Strimzi's Kafka init container reads its Kubernetes Node to determine the
+# advertised address for the chart's NodePort listener.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.fullnameOverride }}-node-reader
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.fullnameOverride }}-node-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.fullnameOverride }}-node-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.fullnameOverride }}-kafka
+    namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
## Summary

Fix three default Kafka deployment problems that prevented a newly generated Kafka platform from starting successfully.

## Git chart revision

For a Git-backed source, Argo CD interprets `targetRevision` as a Git reference. It must resolve to one of the following:

- A branch, such as `main`
- A Git tag, such as `v0.1.0`
- A commit SHA
- Another valid Git reference, such as `HEAD`

The Helm `Chart.yaml` version is not automatically a Git reference.

### Before

Mindweaver supplied the Kafka Helm chart version as the Git revision:

```yaml
repoURL: https://github.com/kagesenshi/mindweaver.git
targetRevision: 0.1.0
path: charts/kafka
```

Although the Kafka chart declares version `0.1.0`, the repository does not have a branch, tag, or commit reference named `0.1.0`.

Argo CD therefore failed with:

```text
unable to resolve '0.1.0' to a commit SHA
```

### After

The source now uses the existing `main` Git branch:

```yaml
repoURL: https://github.com/kagesenshi/mindweaver.git
targetRevision: main
path: charts/kafka
```

The Helm chart version remains defined separately inside:

```text
charts/kafka/Chart.yaml
```

## Kafka image

### Before

The generated Kafka resource used:

```text
apache/kafka:4.0.0-rev.0
```

That image tag does not exist and does not match the configured Kafka version `3.7.0`.

### After

The default image matches the pinned Strimzi operator and Kafka version:

```text
quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
```

## NodePort RBAC

### Before

The Kafka chart enabled an external NodePort listener, but the generated Kafka service account could not read Kubernetes Nodes:

```text
cannot get resource "nodes" at the cluster scope
```

This caused the Strimzi `kafka-init` container to fail.

### After

The chart creates a minimal ClusterRole and ClusterRoleBinding granting the generated Kafka service account:

```yaml
resources: ["nodes"]
verbs: ["get"]
```

## Testing

- Built the Docker test image
- Ran `tests/platform_service/test_kafka.py`
- Result: 12 tests passed