### PR TITLE
Fix Airflow NodePort configuration and external URLS

### DIFF
--- a/backend/src/mindweaver/platform_service/airflow/poller.py
+++ b/backend/src/mindweaver/platform_service/airflow/poller.py
@@ -13,6 +13,39 @@ from .service import AirflowPlatformService
 logger = logging.getLogger(__name__)
 
 
+def _derive_airflow_uris(
+    status, service_name, ingress_domain, node_ports, cluster_nodes
+):
+    if status != "online":
+        return None, None
+
+    if ingress_domain:
+        return f"https://{service_name}.{ingress_domain}", None
+
+    airflow_np = next(
+        (
+            port
+            for port in node_ports
+            if port.get("name") == f"{service_name}-api-server"
+            and port.get("port") == 8080
+            and port.get("node_port")
+        ),
+        None,
+    )
+    if not airflow_np:
+        return None, None
+
+    node_v4 = next((node for node in cluster_nodes if node.get("ipv4")), None)
+    node_v6 = next((node for node in cluster_nodes if node.get("ipv6")), None)
+    ipv4_uri = (
+        f"http://{node_v4['ipv4']}:{airflow_np['node_port']}" if node_v4 else None
+    )
+    ipv6_uri = (
+        f"http://[{node_v6['ipv6']}]:{airflow_np['node_port']}" if node_v6 else None
+    )
+    return ipv4_uri, ipv6_uri
+
+
 @AirflowPlatformService.register_poller()
 class AirflowPoller:
     """Poller for Airflow platform service."""
@@ -166,44 +199,13 @@ class AirflowPoller:
         state.admin_user = "admin"
         state.admin_password = decrypt_password(self.model.admin_password)
 
-        # Derive Airflow URI
-        if status == "online":
-            if project.ingress_domain:
-                state.airflow_uri = f"https://{self.model.name}.{project.ingress_domain}"
-                state.airflow_uri_ipv6 = None
-            elif cluster_nodes:
-                airflow_np = next(
-                    (np for np in node_ports if np["name"] == self.model.name), None
-                )
-                if airflow_np:
-                    node_v4 = next((n for n in cluster_nodes if n["ipv4"]), None)
-                    if node_v4:
-                        state.airflow_uri = (
-                            f"http://{node_v4['ipv4']}:{airflow_np['node_port']}"
-                        )
-                    else:
-                        state.airflow_uri = None
-
-                    node_v6 = next((n for n in cluster_nodes if n["ipv6"]), None)
-                    if node_v6:
-                        state.airflow_uri_ipv6 = (
-                            f"http://[{node_v6['ipv6']}]:{airflow_np['node_port']}"
-                        )
-                    else:
-                        state.airflow_uri_ipv6 = None
-                else:
-                    state.airflow_uri = (
-                        f"http://{self.model.name}.{namespace}.svc.cluster.local:8080"
-                    )
-                    state.airflow_uri_ipv6 = None
-            else:
-                state.airflow_uri = (
-                    f"http://{self.model.name}.{namespace}.svc.cluster.local:8080"
-                )
-                state.airflow_uri_ipv6 = None
-        else:
-            state.airflow_uri = None
-            state.airflow_uri_ipv6 = None
+        state.airflow_uri, state.airflow_uri_ipv6 = _derive_airflow_uris(
+            status,
+            self.model.name,
+            project.ingress_domain,
+            node_ports,
+            cluster_nodes,
+        )
 
         state.last_heartbeat = ts_now()
         await self.service.session.flush()

--- a/backend/src/mindweaver/platform_service/airflow/templates/10-application.yml.j2
+++ b/backend/src/mindweaver/platform_service/airflow/templates/10-application.yml.j2
@@ -52,6 +52,8 @@ spec:
         apiSecretKey: "{{ webserver_secret_key }}"
 
         apiServer:
+          service:
+            type: NodePort
           resources:
             requests:
               cpu: {{ cpu_request }}
@@ -239,9 +241,6 @@ spec:
 
         ingress:
           enabled: false
-
-        service:
-          type: NodePort
 
         extraEnv: |
           - name: AIRFLOW__CORE__LOAD_EXAMPLES

--- a/backend/tests/platform_service/test_airflow.py
+++ b/backend/tests/platform_service/test_airflow.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPLv3+
 
 import pytest
+import yaml
 from unittest.mock import MagicMock, AsyncMock, patch
 from fastapi.testclient import TestClient
 from mindweaver.app import app
@@ -383,6 +384,14 @@ async def test_airflow_load_examples(test_project):
         manifests = await svc.render_manifests(airflow_model_true)
         assert "AIRFLOW__CORE__LOAD_EXAMPLES" in manifests
         assert "value: \"True\"" in manifests
+        app = next(
+            doc
+            for doc in yaml.safe_load_all(manifests)
+            if doc and doc.get("kind") == "Application"
+        )
+        values = yaml.safe_load(app["spec"]["source"]["helm"]["values"])
+        assert values["apiServer"]["service"]["type"] == "NodePort"
+        assert "service" not in values
 
     # 2. Test load_examples is False
     airflow_model_false = AirflowPlatform(
@@ -396,4 +405,38 @@ async def test_airflow_load_examples(test_project):
         manifests = await svc.render_manifests(airflow_model_false)
         assert "AIRFLOW__CORE__LOAD_EXAMPLES" in manifests
         assert "value: \"False\"" in manifests
+
+
+def test_airflow_external_uri_requires_an_allocated_nodeport():
+    from mindweaver.platform_service.airflow.poller import _derive_airflow_uris
+
+    nodes = [{"ipv4": "10.10.101.137", "ipv6": None}]
+
+    assert _derive_airflow_uris("online", "priority-airflow", None, [], nodes) == (
+        None,
+        None,
+    )
+    assert _derive_airflow_uris(
+        "online",
+        "priority-airflow",
+        None,
+        [{"name": "another-service", "port": 8080, "node_port": 30080}],
+        nodes,
+    ) == (None, None)
+    assert _derive_airflow_uris(
+        "online",
+        "priority-airflow",
+        None,
+        [
+            {
+                "name": "priority-airflow-api-server",
+                "port": 8080,
+                "node_port": 31808,
+            }
+        ],
+        nodes,
+    ) == ("http://10.10.101.137:31808", None)
+    assert _derive_airflow_uris(
+        "online", "priority-airflow", "example.com", [], nodes
+    ) == ("https://priority-airflow.example.com", None)
 

--- a/frontend/src/pages/airflow/ServiceView.jsx
+++ b/frontend/src/pages/airflow/ServiceView.jsx
@@ -93,7 +93,6 @@ const ServiceView = ({
         }
 
         const ports = [];
-        let isIngressUsed = false;
         const ingressDomain = platformState?.extra_data?.ingress_domain;
 
         if (airflowUriObj && ingressDomain && airflowUriObj.hostname.endsWith(ingressDomain)) {
@@ -103,7 +102,6 @@ const ServiceView = ({
                 port: airflowUriObj.port ? parseInt(airflowUriObj.port) : (airflowUriObj.protocol === 'https:' ? 443 : 80),
                 scheme: airflowUriObj.protocol.replace(':', '')
             });
-            isIngressUsed = true;
         }
 
         const httpPort = platformState?.node_ports?.find(np => np.port === 8080);
@@ -112,12 +110,6 @@ const ServiceView = ({
                 label: 'Airflow Web UI (NodePort)',
                 node_port: httpPort.node_port,
                 scheme: airflowUriObj ? airflowUriObj.protocol.replace(':', '') : 'http'
-            });
-        } else if (!isIngressUsed && airflowUriObj) {
-            ports.push({
-                label: 'Airflow Web UI (NodePort)',
-                node_port: airflowUriObj.port ? parseInt(airflowUriObj.port) : 8080,
-                scheme: airflowUriObj.protocol.replace(':', '')
             });
         }
 


### PR DESCRIPTION
## Summary

Correct the Airflow API server NodePort configuration and stop displaying external URLs that do not correspond to an allocated Kubernetes NodePort.

## NodePort configuration

### Before

Mindweaver generated the NodePort setting at the root of the Airflow Helm values:

```yaml
service:
  type: NodePort
```

The selected Airflow chart does not use this value for the API server. The generated API server Service therefore remained:

```text
ClusterIP
```

### After

Mindweaver now configures the API server Service through the chart's expected value:

```yaml
apiServer:
  service:
    type: NodePort
```

Kubernetes can therefore allocate a real NodePort for the Airflow API server.

## External URL reporting

### Before

When no matching NodePort was found, Mindweaver treated Airflow's internal service port `8080` as an external NodePort and displayed URLs such as:

```text
http://10.10.101.137:8080
```

These URLs could not be reached from outside the cluster.

### After

Mindweaver now:

- Selects the `<release>-api-server` Service
- Requires its internal service port to be `8080`
- Requires Kubernetes to provide an allocated `nodePort`
- Builds the external URL using that allocated port
- Returns no external URL when neither Ingress nor NodePort access exists

Example:

```text
http://10.10.101.137:31808
```

The frontend no longer fabricates a NodePort entry from a fallback URI.

## Testing

- Built the Docker backend test image
- Ran `tests/platform_service/test_airflow.py`
- Result: 6 tests passed
- Ran frontend ESLint successfully